### PR TITLE
get rid of text-align-center on article toppers

### DIFF
--- a/web/wp-content/themes/mozilla-labs/templates/components/articles/toppers/topper--small_image.twig
+++ b/web/wp-content/themes/mozilla-labs/templates/components/articles/toppers/topper--small_image.twig
@@ -10,7 +10,7 @@
           {% include 'components/articles/overline.twig' with { overline: post.categories[0] } %}
         </div>
 
-        <h1 class="type-headline-40 text-balance text-center leading-none">{{ post.title }}</h1>
+        <h1 class="type-headline-40 text-balance leading-none">{{ post.title }}</h1>
       </div>
     </div>
 

--- a/web/wp-content/themes/mozilla-labs/templates/components/articles/toppers/topper--text_only.twig
+++ b/web/wp-content/themes/mozilla-labs/templates/components/articles/toppers/topper--text_only.twig
@@ -6,7 +6,7 @@
           {% include 'components/articles/overline.twig' with { overline: post.categories[0] } %}
         </div>
 
-        <h1 class="type-headline-40 text-balance text-center leading-none">{{ post.title }}</h1>
+        <h1 class="type-headline-40 text-balance leading-none">{{ post.title }}</h1>
       </div>
     </div>
 


### PR DESCRIPTION
## Changes

Make all article headlines left-aligned

(image of expected results)

## How To Test

(necessary config changes)

(how to access the new / changed functionality -- fixtures, URLs)

## TODOs:

- [ ] Updated editor documentation
- [ ] Updated Trello status

### Optional:

- [ ] <a href="https://cpi-pa11y.herokuapp.com/" target="_blank">Run and add accessibility test</a>
- [ ] Add Cypress interaction test
