### PR TITLE
get rid of min-h in typewriter topper

### DIFF
--- a/web/wp-content/themes/mozilla-labs/templates/components/typewriter-headline-topper.twig
+++ b/web/wp-content/themes/mozilla-labs/templates/components/typewriter-headline-topper.twig
@@ -1,6 +1,6 @@
 <header class="text-content grid grid-site mt-[25vh]">
-  <div class="col-span-full md:col-start-3 md:col-end-11 flex flex-col gap-12 items-center">
-    <p class="group type-headline-80 text-center min-h-[6lh] sm:min-h-[4lh]" x-init x-typewriter>
+  <div class="col-span-full md:col-start-3 md:col-end-11 flex flex-col gap-y-16 md:gap-y-20 items-center">
+    <p class="group type-headline-80 text-center" x-init x-typewriter>
       <span class="text-balance block">{{ static_text }}</span>
 
       <span class="inline-grid">


### PR DESCRIPTION
## Changes

@gvjacob sorry about missing your comment – I thought the topper was still shifting, so added the min-h. Didn't realize you were already dealing with that with grid-rows!

(image of expected results)

## How To Test

(necessary config changes)

(how to access the new / changed functionality -- fixtures, URLs)

## TODOs:

- [ ] Updated editor documentation
- [ ] Updated Trello status

### Optional:

- [ ] <a href="https://cpi-pa11y.herokuapp.com/" target="_blank">Run and add accessibility test</a>
- [ ] Add Cypress interaction test
