### PR TITLE
Update package.json to v0.1.1 restore sequential versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstatement/mozilla-labs",
-  "version": "0.0.6",
+  "version": "0.1.1",
   "description": "Theme for Mozilla Labs",
   "author": "Upstatement",
   "repository": "",

--- a/web/wp-content/themes/mozilla-labs/style.css
+++ b/web/wp-content/themes/mozilla-labs/style.css
@@ -2,5 +2,5 @@
  * Theme Name: Mozilla Labs
  * Description:
  * Author: Upstatement
- * Version: 0.0.6
+ * Version: 0.1.1
  */


### PR DESCRIPTION
Version numbers regressed to pre 0.1.0, and it was causing issues with release tagging in GitHub, this jumps to v0.1.1 to establish a new latest version we can increment from now on.