### PR TITLE
Remove `main` as a branch target

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -2,7 +2,6 @@ name: Test and deploy
 on:
   push:
     branches:
-      - main
       - develop
   release:
     types: [created]


### PR DESCRIPTION
## Changes

The Builders repo uses Releases as the targets for production deployment rather than pushes to `main`. This removes `main` as a target branch for these builds, which should prevent duplicate builds occurring when merges into `main` are performed.

This is a little chore to save for after we get more critical work out, primarily a github actions optimization.

## How To Test

* next time a branch is merged into `main`, confirm that an action does not trigger to re-deploy it to the staging environment.
* when deploying, bump the version number and create a tag to match. create a Release in GitHub for it and confirm that production is updated

## TODOs:

- [ ] Updated editor documentation
- [ ] Updated Trello status

### Optional:

- [ ] <a href="https://cpi-pa11y.herokuapp.com/" target="_blank">Run and add accessibility test</a>
- [ ] Add Cypress interaction test
